### PR TITLE
Allow to set pipeline from closure while avoiding lifetime issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
                 a: 1.0,
             };
             renderer.render_pass(CORNFLOWER_BLUE, |render_pass| {
-                //render_pass.set_pipeline(&sprite_render_pipeline);
+                render_pass.set_pipeline(sprite_render_pipeline);
             });
         }
         Event::MainEventsCleared => {


### PR DESCRIPTION
This is the same approach as used in Bevy. You avoid the lifetime issue by using an index/id instead of a reference. This basically exchanges compile time checks for run time panics.